### PR TITLE
Allow custom semantic-ui builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,9 @@ var defaults = {
   css: true,
   javascript: true,
   fonts: true,
-  images: true
+  images: true,
+  path: 'bower_components/semantic-ui/dist',
+  theme: 'default'
 };
 
 var getWithDefault = function(property, default_property) {
@@ -21,32 +23,34 @@ module.exports = {
 
   included: function (app) {
     var options = (app && app.options['SemanticUI']) || {};
+    var path = getWithDefault(options['path'], defaults['path']);
+    var theme = getWithDefault(options['theme'], defaults['theme']);
 
     if (getWithDefault(options['css'], defaults['css'])) {
       app.import({
-        development: 'bower_components/semantic-ui/dist/semantic.css',
-        production: 'bower_components/semantic-ui/dist/semantic.min.css'
+        development: path + '/semantic.css',
+        production: path + '/semantic.min.css'
       });
     }
 
     if (getWithDefault(options['javascript'], defaults['javascript'])) {
       app.import({
-        development: 'bower_components/semantic-ui/dist/semantic.js',
-        production: 'bower_components/semantic-ui/dist/semantic.min.js'
+        development: path + '/semantic.js',
+        production: path + '/semantic.min.js'
       });
     }
 
     if (getWithDefault(options['images'], defaults['images'])) {
-      var imageOptions = { destDir: 'assets/themes/default/assets/images' };
-      app.import('bower_components/semantic-ui/dist/themes/default/assets/images/flags.png', imageOptions);
+      var imageOptions = { destDir: 'assets/themes/' + theme + '/assets/images' };
+      app.import(path + '/themes/' + theme + '/assets/images/flags.png', imageOptions);
     }
 
     if (getWithDefault(options['fonts'], defaults['fonts'])) {
       var fontExtensions = ['.eot','.otf','.svg','.ttf','.woff','.woff2'];
-      var fontOptions = { destDir: 'assets/themes/default/assets/fonts' };
+      var fontOptions = { destDir: 'assets/themes/' + theme + '/assets/fonts' };
       for (var i = fontExtensions.length - 1; i >= 0; i--) {
-        app.import('bower_components/semantic-ui/dist/themes/default/assets/fonts/icons'+fontExtensions[i], fontOptions);
-      };
+        app.import(path + '/themes/' + theme + '/assets/fonts/icons'+fontExtensions[i], fontOptions);
+      }
     }
   }
 };


### PR DESCRIPTION
Adds two configuration options. One for the path to the `dist` folder of
Semantic. The other option to specify the theme used for images and
fonts.

Note that this does not add support for importing files outside of the
build tree (e.g. `bower_components`). One can use `bower link` for local
projects.
